### PR TITLE
Feat: 사용자 인증 시 Secret Key 검증 로직 추가

### DIFF
--- a/src/main/java/ASAC/Springmaster/security/configs/SecurityConfig.java
+++ b/src/main/java/ASAC/Springmaster/security/configs/SecurityConfig.java
@@ -1,8 +1,10 @@
 package ASAC.Springmaster.security.configs;
 
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationDetailsSource;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -10,6 +12,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
 
 @EnableWebSecurity
 @Configuration
@@ -17,6 +20,7 @@ import org.springframework.security.web.SecurityFilterChain;
 public class SecurityConfig {
 
     private final AuthenticationProvider authenticationProvider;
+    private final AuthenticationDetailsSource<HttpServletRequest, WebAuthenticationDetails> authenticationDetailsSource;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {  // 여기서 별도의 설정을 할수잇다
@@ -27,7 +31,10 @@ public class SecurityConfig {
                         .requestMatchers("/","signup" +
                                 "").permitAll()
                         .anyRequest().authenticated())
-                .formLogin(form -> form.loginPage("/login").permitAll())
+                .formLogin(form -> form
+                        .loginPage("/login").permitAll()
+                        .authenticationDetailsSource(authenticationDetailsSource)
+                )
                 .authenticationProvider(authenticationProvider)
         ;
 

--- a/src/main/java/ASAC/Springmaster/security/details/FormAuthenticationDetails.java
+++ b/src/main/java/ASAC/Springmaster/security/details/FormAuthenticationDetails.java
@@ -1,0 +1,17 @@
+package ASAC.Springmaster.security.details;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.Getter;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+
+@Getter
+public class FormAuthenticationDetails extends WebAuthenticationDetails {
+
+    private String secretKey;
+
+
+    public FormAuthenticationDetails(HttpServletRequest request) {
+        super(request);
+        this.secretKey = request.getParameter("secret_key");
+    }
+}

--- a/src/main/java/ASAC/Springmaster/security/details/FormWebAuthenticationDetailsSource.java
+++ b/src/main/java/ASAC/Springmaster/security/details/FormWebAuthenticationDetailsSource.java
@@ -1,0 +1,15 @@
+package ASAC.Springmaster.security.details;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.authentication.AuthenticationDetailsSource;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FormWebAuthenticationDetailsSource implements AuthenticationDetailsSource<HttpServletRequest, WebAuthenticationDetails> {
+
+    @Override
+    public WebAuthenticationDetails buildDetails(HttpServletRequest request) {
+        return new FormAuthenticationDetails(request);
+    }
+}

--- a/src/main/java/ASAC/Springmaster/security/exception/SecretException.java
+++ b/src/main/java/ASAC/Springmaster/security/exception/SecretException.java
@@ -1,0 +1,10 @@
+package ASAC.Springmaster.security.exception;
+
+
+import org.springframework.security.core.AuthenticationException;
+
+public class SecretException extends AuthenticationException {
+    public SecretException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/ASAC/Springmaster/security/provider/FormAuthenticationProvider.java
+++ b/src/main/java/ASAC/Springmaster/security/provider/FormAuthenticationProvider.java
@@ -1,6 +1,8 @@
 package ASAC.Springmaster.security.provider;
 
 import ASAC.Springmaster.domain.dto.AccountContext;
+import ASAC.Springmaster.security.details.FormAuthenticationDetails;
+import ASAC.Springmaster.security.exception.SecretException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -28,6 +30,12 @@ public class FormAuthenticationProvider implements AuthenticationProvider {
         if(!passwordEncoder.matches(password, accountContext.getPassword())){
             throw new BadCredentialsException("Invalid password");
         }
+
+        String secretKey = ((FormAuthenticationDetails) authentication.getDetails()).getSecretKey();
+        if(secretKey == null || !secretKey.equals("secret")){
+            throw new SecretException("Invalid secret");
+        }
+
         return new UsernamePasswordAuthenticationToken(accountContext.getAccountDto(), null, accountContext.getAuthorities());
     }
 

--- a/src/main/resources/templates/login/login.html
+++ b/src/main/resources/templates/login/login.html
@@ -98,6 +98,7 @@
                     <span th:text="${exception}?: '잘못된 아이디나 암호입니다'" class="alert alert-danger"></span>
                 </div>
                 <form th:action="@{/login}" method="post"> <!-- 이렇게 해줘야 csrf 토큰이 자동으로 생성된다 -->
+                    <input type="hidden" th:value="secret" th:name="secret_key"/>
                     <div class="form-group">
                         <label for="username">Username</label>
                         <input type="text" class="form-control" id="username" name="username" required>


### PR DESCRIPTION
- FormAuthenticationDetails에서 요청의 Secret Key를 추출하는 로직 구현
- Secret Key가 유효하지 않을 경우 SecretException 예외 발생 처리
- FormWebAuthenticationDetailsSource를 통해 커스텀 인증 세부 정보 처리 추가
- 로그인 폼에 Hidden Field로 Secret Key 값 전달