### PR TITLE
Feat: 인증 및 인가 처리 로직 구현

### DIFF
--- a/src/main/java/ASAC/Springmaster/security/handler/FormAccessDeniedHandler.java
+++ b/src/main/java/ASAC/Springmaster/security/handler/FormAccessDeniedHandler.java
@@ -1,0 +1,27 @@
+package ASAC.Springmaster.security.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.DefaultRedirectStrategy;
+import org.springframework.security.web.RedirectStrategy;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import java.io.IOException;
+
+public class FormAccessDeniedHandler implements AccessDeniedHandler {
+    private final RedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
+    private final String errorPage;
+
+    public FormAccessDeniedHandler(String errorPage) {
+        this.errorPage = errorPage;
+    }
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+
+        String deniedUrl = errorPage + "?exception=" + accessDeniedException.getMessage();
+        redirectStrategy.sendRedirect(request, response, deniedUrl);
+
+    }
+}

--- a/src/main/java/ASAC/Springmaster/security/handler/FormAuthenticationFailureHandler.java
+++ b/src/main/java/ASAC/Springmaster/security/handler/FormAuthenticationFailureHandler.java
@@ -1,0 +1,43 @@
+package ASAC.Springmaster.security.handler;
+
+import ASAC.Springmaster.security.exception.SecretException;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.CredentialsExpiredException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class FormAuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(final HttpServletRequest request, final HttpServletResponse response, final AuthenticationException exception) throws IOException, ServletException {
+
+        String errorMessage = "Invalid Username or Password";
+
+        if(exception instanceof BadCredentialsException) {
+            errorMessage = "Invalid Username or Password";
+        }
+        else if(exception instanceof UsernameNotFoundException) {
+            errorMessage = "User not exists";
+        }
+        else if(exception instanceof CredentialsExpiredException) {
+            errorMessage = "Expired password";
+
+        }else if(exception instanceof SecretException) {
+            errorMessage = "Invalid Secret key";
+        }
+
+        setDefaultFailureUrl("/login?error=true&exception=" + errorMessage);
+
+        super.onAuthenticationFailure(request, response, exception);
+
+    }
+}

--- a/src/main/java/ASAC/Springmaster/security/handler/FormAuthenticationSuccessHandler.java
+++ b/src/main/java/ASAC/Springmaster/security/handler/FormAuthenticationSuccessHandler.java
@@ -1,0 +1,35 @@
+package ASAC.Springmaster.security.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.DefaultRedirectStrategy;
+import org.springframework.security.web.RedirectStrategy;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
+import org.springframework.security.web.savedrequest.RequestCache;
+import org.springframework.security.web.savedrequest.SavedRequest;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class FormAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final RequestCache requestCache = new HttpSessionRequestCache();
+    private final RedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        setDefaultTargetUrl("/");
+
+        SavedRequest savedRequest = requestCache.getRequest(request, response);
+        if(savedRequest != null){
+            String targetUrl = savedRequest.getRedirectUrl();
+            redirectStrategy.sendRedirect(request, response, targetUrl);
+        }else {
+            redirectStrategy.sendRedirect(request, response, getDefaultTargetUrl());
+        }
+    }
+}

--- a/src/main/java/ASAC/Springmaster/security/provider/FormAuthenticationProvider.java
+++ b/src/main/java/ASAC/Springmaster/security/provider/FormAuthenticationProvider.java
@@ -35,7 +35,6 @@ public class FormAuthenticationProvider implements AuthenticationProvider {
         if(secretKey == null || !secretKey.equals("secret")){
             throw new SecretException("Invalid secret");
         }
-
         return new UsernamePasswordAuthenticationToken(accountContext.getAccountDto(), null, accountContext.getAuthorities());
     }
 

--- a/src/main/java/ASAC/Springmaster/users/controller/LoginController.java
+++ b/src/main/java/ASAC/Springmaster/users/controller/LoginController.java
@@ -1,32 +1,46 @@
 package ASAC.Springmaster.users.controller;
 
+import ASAC.Springmaster.domain.dto.AccountDto;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 public class LoginController {
-    @GetMapping("/login")
-    public String login(){
+    @GetMapping(value="/login")
+    public String login(@RequestParam(value = "error", required = false) String error,
+                        @RequestParam(value = "exception", required = false) String exception, Model model){
+        model.addAttribute("error",error);
+        model.addAttribute("exception",exception);
         return "login/login";
     }
 
-    @GetMapping("/signup")
-    public String signup(){
+    @GetMapping(value="/signup")
+    public String signup() {
         return "login/signup";
     }
 
-    @GetMapping("/logout")
-    public String logout(HttpServletRequest request, HttpServletResponse response){
+    @GetMapping(value = "/logout")
+    public String logout(HttpServletRequest request, HttpServletResponse response) {
         Authentication authentication = SecurityContextHolder.getContextHolderStrategy().getContext().getAuthentication();
-        if(authentication != null){
+        if (authentication != null) {
             new SecurityContextLogoutHandler().logout(request, response, authentication);
         }
         return "redirect:/login";
     }
+    @GetMapping(value="/denied")
+    public String accessDenied(@RequestParam(value = "exception", required = false) String exception, @AuthenticationPrincipal AccountDto accountDto, Model model) {
 
+        model.addAttribute("username", accountDto.getUsername());
+        model.addAttribute("exception", exception);
+
+        return "login/denied";
+    }
 }

--- a/src/main/resources/templates/login/denied.html
+++ b/src/main/resources/templates/login/denied.html
@@ -58,7 +58,7 @@
             color: #fff; /* 마우스 오버시 글자색 */
         }
         /* 중앙 로그인 폼 스타일 */
-        .signup-form {
+        .login-form {
             max-width: 400px;
             margin: 30px auto;
             padding: 20px;
@@ -66,16 +66,16 @@
             border-radius: 5px;
             box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
         }
-        .signup-form h2 {
+        .login-form h2 {
             color: #fff; /* 밝은 글자색 */
             margin-bottom: 20px;
         }
-        .signup-form .form-control {
+        .login-form .form-control {
             background-color: #3a3b45; /* 어두운 입력 필드 배경색 */
             color: #fff; /* 밝은 입력 필드 글자색 */
             border: none;
         }
-        .signup-form .btn-primary {
+        .login-form .btn-primary {
             background-color: #4e73df; /* 밝은 버튼 색상 */
             border: none;
         }
@@ -92,31 +92,10 @@
             <div th:replace="~{layout/sidebar::sidebar}"></div>
         </div>
         <div class="col-md-10 content">
-            <div class="signup-form">
-                <h2>Sign Up</h2>
-                <form th:action="@{/signup}" method="post">
-                    <div class="form-group">
-                        <label for="username">Username</label>
-                        <input type="text" class="form-control" id="username" name="username" required>
-                    </div>
-                    <div class="form-group">
-                        <label for="password">Password</label>
-                        <input type="password" class="form-control" id="password" name="password" required>
-                    </div>
-                    <div class="form-group">
-                        <label for="age">Age</label>
-                        <input type="number" class="form-control" id="age" name="age" required>
-                    </div>
-                    <div class="form-group">
-                        <label for="roles">Authority</label>
-                        <select class="form-control" id="roles" name="roles">
-                            <option>ROLE_USER</option>
-                            <option>ROLE_MANAGER</option>
-                            <option>ROLE_ADMIN</option>
-                        </select>
-                    </div>
-                    <button type="submit" class="btn btn-primary">Sign Up</button>
-                </form>
+            <div>
+                <h3 th:text="${exception}"></h3>
+                <br />
+                <span th:text="${username} != null ? ${username} + ' 님은 접근 권한이 없습니다' : '비 정상적인 접근입니다'" ></span>
             </div>
         </div>
     </div>


### PR DESCRIPTION
- FormAccessDeniedHandler를 통해 접근 거부 시 에러 페이지로 리다이렉트 처리
- FormAuthenticationFailureHandler에서 인증 실패 시 예외 유형에 따른 에러 메시지 처리 추가 (비밀번호 오류, 사용자 미존재, 만료된 비밀번호, Secret Key 오류 등)
- FormAuthenticationSuccessHandler에서 인증 성공 시 저장된 요청이 있을 경우 해당 URL로 리다이렉트, 없을 경우 기본 페이지로 리다이렉트 처리
- 로그인 페이지에서 에러 메시지와 예외 메시지를 모델에 전달하여 화면에 표시
- 각 역할별 권한 설정 추가 (ROLE_USER, ROLE_MANAGER, ROLE_ADMIN에 따른 페이지 접근 제한 설정)